### PR TITLE
fixing compile warnings for parse_request and parse_push

### DIFF
--- a/unix/yun/client.c
+++ b/unix/yun/client.c
@@ -52,7 +52,7 @@ int tcp_connect(const char *host, int port)
 }
 
 int tcp_close(int sock) {
-  close(sock);
+  return close(sock);
 }
 
 int tcp_write(int sock, char* data) {

--- a/unix/yun/parse_push.c
+++ b/unix/yun/parse_push.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <parse.h>
 
+#include "utils.h"
 #include "yun.h"
 
 #define PARSE_BUFSIZE 2048

--- a/unix/yun/parse_request.c
+++ b/unix/yun/parse_request.c
@@ -24,6 +24,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "client.h"
+#include "utils.h"
 #include "yun.h"
 
 #define PARSE_BUFSIZE 2048
@@ -57,7 +59,7 @@ void arduinoQueryHandler(ParseClient client, int error, int httpStatus, const ch
   while(1){
     ch = fgetc(stdin); //read(stdin, &ch, 1);
     if(ch == 'n') { // nextObject() called in Arduino
-      next = getNextFromJSONArray(next, next + nextSize, &nextSize);
+      next = (char *)getNextFromJSONArray(next, next + nextSize, &nextSize);
       if (nextSize > 0 && next) {
         char* object = malloc(sizeof(char) * (nextSize+1));
         snprintf(object, nextSize+1, "%s", next);

--- a/unix/yun/yun.c
+++ b/unix/yun/yun.c
@@ -25,6 +25,8 @@
 #include <string.h>
 #include <parse.h>
 
+#include "client.h"
+#include "utils.h"
 #include "yun.h"
 
 char g_cAppID[APPLICATION_ID_MAX_LEN + 1];


### PR DESCRIPTION
Including header files that were omitted and adding explicit cast from const char* to char*.