### PR TITLE
add desctrutors for ParseResponse & ParseClient

### DIFF
--- a/yun/libraries/Parse/src/internal/ParseClient.cpp
+++ b/yun/libraries/Parse/src/internal/ParseClient.cpp
@@ -24,64 +24,68 @@
 ParseClient::ParseClient() {
 }
 
-void ParseClient::begin(const char *applicationId, const char *clientKey) {
-	Console.println("begin");
+ParseClient::~ParseClient() {
+  end();
+}
 
-	// send the info to linux through Bridge
-	if(applicationId) {
-		Bridge.put("appId", applicationId);
-	}
-	if (clientKey) {
-		Bridge.put("clientKey", clientKey);
-	}
+void ParseClient::begin(const char *applicationId, const char *clientKey) {
+  Console.println("begin");
+
+  // send the info to linux through Bridge
+  if(applicationId) {
+    Bridge.put("appId", applicationId);
+  }
+  if (clientKey) {
+    Bridge.put("clientKey", clientKey);
+  }
 }
 
 void ParseClient::setInstallationId(const char *installationId) {
-	this->installationId = installationId;
-	if (installationId) {
-		Bridge.put("installationId", installationId);
-	} else {
-		Bridge.put("installationId", "");
-	}
+  this->installationId = installationId;
+  if (installationId) {
+    Bridge.put("installationId", installationId);
+  } else {
+    Bridge.put("installationId", "");
+  }
 }
 
 const char* ParseClient::getInstallationId() {
-	if (!this->installationId) {
-		char *buf = new char[37];
+  if (!this->installationId) {
+    char *buf = new char[37];
 
-		requestClient.begin("parse_request");
-		requestClient.addParameter("-i");
-		requestClient.run();
+    requestClient.begin("parse_request");
+    requestClient.addParameter("-i");
+    requestClient.run();
     read(&requestClient, buf, 37);
-		this->installationId = buf;
-	}
-	return this->installationId;
+    this->installationId = buf;
+  }
+  return this->installationId;
 }
 
 void ParseClient::setSessionToken(const char *sessionToken) {
-	if ((sessionToken != NULL) && (strlen(sessionToken) > 0 )){
-		this->sessionToken = sessionToken;
-		Bridge.put("sessionToken", sessionToken);
-	} else {
-	  Bridge.put("sessionToken", "");
-	}
+  if ((sessionToken != NULL) && (strlen(sessionToken) > 0 )){
+    this->sessionToken = sessionToken;
+    Bridge.put("sessionToken", sessionToken);
+  } else {
+    Bridge.put("sessionToken", "");
+  }
 }
 
 void ParseClient::clearSessionToken() {
-	setSessionToken(NULL);
+  setSessionToken(NULL);
 }
 
 const char* ParseClient::getSessionToken() {
-	if (!this->sessionToken) {
-		char *buf = new char[33];
+  if (!this->sessionToken) {
+    char *buf = new char[33];
 
-		requestClient.begin("parse_request");
-		requestClient.addParameter("-s");
-		requestClient.run();
-		read(&requestClient, buf, 33);
-		this->sessionToken = buf;
-	}
-	return this->sessionToken;
+    requestClient.begin("parse_request");
+    requestClient.addParameter("-s");
+    requestClient.run();
+    read(&requestClient, buf, 33);
+    this->sessionToken = buf;
+  }
+  return this->sessionToken;
 }
 
 ParseResponse ParseClient::sendRequest(const char* httpVerb, const char* httpPath, const char* requestBody, const char* urlParams) {
@@ -89,82 +93,89 @@ ParseResponse ParseClient::sendRequest(const char* httpVerb, const char* httpPat
 }
 
 ParseResponse ParseClient::sendRequest(const String& httpVerb, const String& httpPath, const String& requestBody, const String& urlParams) {
-	requestClient.begin("parse_request");  // start a process that launch the "parse_request" command
+  requestClient.begin("parse_request");  // start a process that launch the "parse_request" command
 
-	requestClient.addParameter("-v");
-	requestClient.addParameter(httpVerb);
-	requestClient.addParameter("-e");
-	requestClient.addParameter(httpPath);
-	if (requestBody != "") {
-		requestClient.addParameter("-d");
-		requestClient.addParameter(requestBody);
-	}
-	if (urlParams != "") {
-		requestClient.addParameter("-p");
-		requestClient.addParameter(urlParams);
+  requestClient.addParameter("-v");
+  requestClient.addParameter(httpVerb);
+  requestClient.addParameter("-e");
+  requestClient.addParameter(httpPath);
+  if (requestBody != "") {
+    requestClient.addParameter("-d");
+    requestClient.addParameter(requestBody);
+  }
+  if (urlParams != "") {
+    requestClient.addParameter("-p");
+    requestClient.addParameter(urlParams);
     requestClient.runAsynchronously();
-	} else {
-	  requestClient.run(); // Run the process and wait for its termination
-	}
+  } else {
+    requestClient.run(); // Run the process and wait for its termination
+  }
 
-	ParseResponse response(&requestClient);
-	return response;
+  ParseResponse response(&requestClient);
+  return response;
 }
 
 bool ParseClient::startPushService() {
-	pushClient.begin("parse_push");  // start a process that launch the "parse_request" command
-	pushClient.runAsynchronously();
+  pushClient.begin("parse_push");  // start a process that launch the "parse_request" command
+  pushClient.runAsynchronously();
 
-	while(1) {
-		if(pushClient.available()) {
-			// read the push starting result
-			char c = pushClient.read();
-			while(pushClient.available()) {
-				pushClient.read();
-			}
-			if (c == 's') {
-                 pushClient.write('n'); // send a signal that ready to consume next available push
-				return true;
-			} else {
-				return false;
-			}
-		}
-	}
+  while(1) {
+    if(pushClient.available()) {
+      // read the push starting result
+      char c = pushClient.read();
+      while(pushClient.available()) {
+        pushClient.read();
+      }
+      if (c == 's') {
+        pushClient.write('n'); // send a signal that ready to consume next available push
+        return true;
+      } else {
+        return false;
+      }
+    }
+  }
 }
 
 ParsePush ParseClient::nextPush() {
-	ParsePush push(&pushClient);
-	return push;
+  ParsePush push(&pushClient);
+  return push;
 }
 
 bool ParseClient::pushAvailable() {
-    pushClient.write('n'); // send a signal that ready to consume next available push
-    if(pushClient.available()) {
-        return 1;
-    } else {
-        return 0;
-    }
+  pushClient.write('n'); // send a signal that ready to consume next available push
+  if(pushClient.available()) {
+    return 1;
+  } else {
+    return 0;
+  }
 }
 
 void ParseClient::stopPushService() {
-	pushClient.close();
+  pushClient.close();
 }
 
 void ParseClient::end() {
-	stopPushService();
+  if(installationId) {
+    delete[] installationId;
+  }
+  if(sessionToken) {
+    delete[] sessionToken;
+  }
+
+  stopPushService();
 }
 
 void ParseClient::read(Process* client, char* buf, int len) {
   memset(buf, 0, len);
   int p = 0;
-	while(1) {
-		if(client->available()) {
-			while (p < (len-1) && client->available()) {
-				buf[p++] = client->read();
-			}
-			break;
-		}
-	}
+  while(1) {
+    if(client->available()) {
+      while (p < (len-1) && client->available()) {
+        buf[p++] = client->read();
+      }
+      break;
+    }
+  }
 }
 
 ParseClient Parse;

--- a/yun/libraries/Parse/src/internal/ParseClient.h
+++ b/yun/libraries/Parse/src/internal/ParseClient.h
@@ -49,6 +49,10 @@ public:
    *  \brief Constructor of ParseClient object
    */
   ParseClient();
+  /*! \fn ParseClient()
+   *  \brief Destructor of ParseClient object
+   */
+  ~ParseClient();
 
   /*! \fn begin(const char *applicationId, const char *clientKey)
    *  \brief Initialize the Parse client and user session

--- a/yun/libraries/Parse/src/internal/ParseResponse.h
+++ b/yun/libraries/Parse/src/internal/ParseResponse.h
@@ -50,6 +50,11 @@ protected:
   ParseResponse(Process* client);
 
 public:
+  /*! \fn ParseResponse()
+   *  \brief Destructor of ParseResponse object
+   */
+  ~ParseResponse();
+
   /*! \fn void setBuffer(char* buffer, int size)
    *  \brief set the customer buffer for writing response data.
    *


### PR DESCRIPTION
 We are explicitly asking developers to call close() to release resource, especially memory. Still want to add support to release resource after out of scope by adding desctructors.