### PR TITLE
add string sanity check for parameters in sendRequest

### DIFF
--- a/yun/libraries/Parse/src/internal/ParseClient.cpp
+++ b/yun/libraries/Parse/src/internal/ParseClient.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "ParseClient.h"
+#include "ParseUtils.h"
 
 ParseClient::ParseClient() {
 }
@@ -95,20 +96,25 @@ ParseResponse ParseClient::sendRequest(const char* httpVerb, const char* httpPat
 ParseResponse ParseClient::sendRequest(const String& httpVerb, const String& httpPath, const String& requestBody, const String& urlParams) {
   requestClient.begin("parse_request");  // start a process that launch the "parse_request" command
 
-  requestClient.addParameter("-v");
-  requestClient.addParameter(httpVerb);
-  requestClient.addParameter("-e");
-  requestClient.addParameter(httpPath);
-  if (requestBody != "") {
-    requestClient.addParameter("-d");
-    requestClient.addParameter(requestBody);
-  }
-  if (urlParams != "") {
-    requestClient.addParameter("-p");
-    requestClient.addParameter(urlParams);
-    requestClient.runAsynchronously();
-  } else {
-    requestClient.run(); // Run the process and wait for its termination
+  if( ParseUtils::isSanitizedString(httpVerb)
+  && ParseUtils::isSanitizedString(httpPath)
+  && ParseUtils::isSanitizedString(requestBody)
+  && ParseUtils::isSanitizedString(urlParams)) {
+    requestClient.addParameter("-v");
+    requestClient.addParameter(httpVerb);
+    requestClient.addParameter("-e");
+    requestClient.addParameter(httpPath);
+    if (requestBody != "") {
+      requestClient.addParameter("-d");
+      requestClient.addParameter(requestBody);
+    }
+    if (urlParams != "") {
+      requestClient.addParameter("-p");
+      requestClient.addParameter(urlParams);
+      requestClient.runAsynchronously();
+    } else {
+      requestClient.run(); // Run the process and wait for its termination
+    }
   }
 
   ParseResponse response(&requestClient);

--- a/yun/libraries/Parse/src/internal/ParseUtils.h
+++ b/yun/libraries/Parse/src/internal/ParseUtils.h
@@ -232,6 +232,20 @@ public:
     delete[] value;
     return false;
   }
+
+  static bool isSanitizedString(const String& userData) {
+    static char badChars[] = " \t\n\r";
+    int k;
+    int i;
+    for(k = 0; k < userData.length(); k++) {
+      for(i = 0; i < strlen(badChars); i++) {
+        if(userData[k] == badChars[i]){
+          return false;
+        }
+      }
+    }
+    return true;
+  }
 };
 
 #endif


### PR DESCRIPTION
Issue to fix: ParseClient::sendRequest function executes a system binary in order to send HTTPS requests to the Parse server. It construct a command line using the Process::addParameter function of Arduino’s Process class. addParameter function does not perform any kind of input escaping, which is potentially a security hole.