### PR TITLE
Issue #63, patch for part of unix 

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -50,6 +50,11 @@ extern "C"
  */
 #define CLIENT_KEY_MAX_LEN 40
 
+ /*! \def SERVER_URL_MAX_LEN
+ *  \brief The length of server url
+ */
+#define SERVER_URL_MAX_LEN 256
+
 /*! \def OBJECT_ID_MAX_LEN
  *  \brief The length of object id
  */
@@ -141,6 +146,25 @@ typedef void (*parsePushCallback)(ParseClient client, int error, const char* dat
  *  The SDK will make copies of the buffers.
  */
 ParseClient parseInitialize(const char *applicationId, const char *clientKey);
+
+/*! \fn ParseClient parseInitializeWithURL(const char *applicationId, const char *clientKey, const char *serverURL)
+ *  \brief Initialize the Parse client and user session with parse server URL
+ *
+ *  This method only initializes the Parse client, used for subsequent API requests with parse-server URL. It does
+ *  not start the push service, and does not create or load the installation object for the client.
+ *
+ *  \param[in]  applicationId    The application id for the Parse application. (required)
+ *  \param[in]  clientKey        The client API key for the Parse application. (required)
+ *  \param[in]  serverURL        The server URL for the Parse-server connection . (required)
+ *
+ *  \result                      The client handle to use with the SDK.
+ *
+ *  The caller retains ownership of the applicationId and clientKey buffers, and is responsible for
+ *  freeing them and reclaiming the memory after this call.
+ *  The SDK will make copies of the buffers.
+ */
+ParseClient parseInitializeWithServerURL(const char *applicationId,  const char *clientKey, const char *serverURL);
+
 
 /*! \fn void parseSetInstallationId(ParseClient client, const char *installationId)
  *  \brief Set the installation object id for this client.

--- a/rtos/parse_impl.c
+++ b/rtos/parse_impl.c
@@ -74,3 +74,55 @@ ParseClient parseInitialize(const char *applicationId, const char *clientKey) {
 ParseClientInternal *getInternalClient(ParseClient client) {
     return (ParseClientInternal *)(client);
 }
+
+
+ParseClient parseInitializeWithServerURL(const char *applicationId, const char *clientKey, const char *serverURL) {
+#ifdef CLIENT_DEBUG
+    DEBUG_PRINT("[Parse] Initializing new client.\r\n");
+#endif /* CLIENT_DEBUG */
+
+    // Do any one-time intialization of the new client
+    ParseClientInternal *parseClient = (ParseClientInternal *)malloc(sizeof(ParseClientInternal));
+
+    if (parseClient != NULL) {
+		memset(parseClient->applicationId, 0, sizeof(parseClient->applicationId));
+		memset(parseClient->clientKey, 0, sizeof(parseClient->clientKey));
+		memset(parseClient->installationObjectId, 0, sizeof(parseClient->installationObjectId));
+		memset(parseClient->installationId, 0, sizeof(parseClient->installationId));
+		memset(parseClient->sessionToken, 0, sizeof(parseClient->sessionToken));
+
+		// Copy the application id and the client key to the client
+		strncpy(parseClient->applicationId, applicationId, APPLICATION_ID_MAX_LEN);
+		strncpy(parseClient->clientKey, clientKey, CLIENT_KEY_MAX_LEN);
+		strncpy(parseClient->serverURL, serverURL, SERVER_URL_MAX_LEN);
+
+#ifdef CLIENT_DEBUG
+		DEBUG_PRINT("[Parse] Application id: %s.\r\n", parseClient->applicationId);
+		DEBUG_PRINT("[Parse] Client key: %s.\r\n", parseClient->clientKey);
+#endif /* CLIENT_DEBUG */
+
+		// initialize the push service data
+		parseClient->socketHandle = -1;
+		parseClient->callback = NULL;
+		parseClient->nFailedPing = 0;
+		memset(parseClient->lastPushTime, 0, sizeof(parseClient->lastPushTime));
+
+		memset(parseClient->osVersion, 0, sizeof(parseClient->osVersion));
+		memset(parseClient->deviceClientVersion, 0, sizeof(parseClient->deviceClientVersion));
+
+		fetchDeviceOSVersion(parseClient->osVersion, sizeof(parseClient->osVersion)-1);
+		strncpy(parseClient->deviceClientVersion, CLIENT_VERSION, CLIENT_VERSION_MAX_LEN);
+
+		loadClientState(parseClient);
+#ifdef CLIENT_DEBUG
+    } else {
+		DEBUG_PRINT("[Parse] Failed to allocate client handle.\r\n");
+#endif /* CLIENT_DEBUG */
+    }
+
+    return (ParseClient)parseClient;
+}
+
+ParseClientInternal *getInternalClient(ParseClient client) {
+    return (ParseClientInternal *)(client);
+}

--- a/rtos/parse_impl.h
+++ b/rtos/parse_impl.h
@@ -83,6 +83,7 @@ typedef struct _ParseClientInternal {
     char installationObjectId[OBJECT_ID_MAX_LEN+1];
     char installationId[INSTALLATION_ID_MAX_LEN+1];
     char sessionToken[SESSION_TOKEN_MAX_LEN+1];
+    char serverURL[SERVER_URL_MAX_LEN];
     parsePushCallback callback;
     int socketHandle;
     int nFailedPing;
@@ -90,7 +91,6 @@ typedef struct _ParseClientInternal {
     char osVersion[OS_VERSION_MAX_LEN+1];
     char deviceClientVersion[CLIENT_VERSION_MAX_LEN+1];
 } ParseClientInternal;
-
 
 
 // SDK functions common for all platforms, implementations are in /rtos folder

--- a/unix/src/parse.c
+++ b/unix/src/parse.c
@@ -43,6 +43,7 @@
 #define PARSE_INSTALLATION_ID "installationID"
 #define PARSE_SESSION_TOKEN "sessionToken"
 #define PARSE_LAST_PUSH_TIME "lastPushTime"
+#define PARSE_DEFAULT_SERVER_URL "https://api.parse.com"
 
 typedef struct _ParseClientInternal {
     const char *applicationId;
@@ -52,6 +53,7 @@ typedef struct _ParseClientInternal {
     char *sessionToken;
     char *osVersion;
     char *lastPushTime;
+    char *serverURL;
     parsePushCallback pushCallback;
     CURL *pushCurlHandle;
     unsigned long long lastHearbeat;
@@ -116,6 +118,50 @@ static size_t curlDataCallback(void *contents, size_t size, size_t nmemb, void *
     free(temp);
 
     return size * nmemb;
+}
+
+ParseClient parseInitializeWithServerURL(
+        const char *applicationId,
+        const char *clientKey,
+        const char *serverURL)
+{
+    parseSetLogLevel(PARSE_LOG_WARN);
+
+    ParseClientInternal *client = calloc(1, sizeof(ParseClientInternal));
+    if (client == NULL) {
+        parseLog(PARSE_LOG_ERROR, "%s:%s generated out of memory.\n", __FUNCTION__, __LINE__);
+        return NULL;
+    }
+    if (applicationId != NULL)
+        client->applicationId= strdup(applicationId);
+    if (clientKey != NULL)
+        client->clientKey = strdup(clientKey);
+    if (serverURL != NULL)
+        client->serverURL = strdup(serverURL);
+
+    char version[256];
+    parseOsGetVersion(version, sizeof(version));
+    client->osVersion = strdup(version);
+
+    char temp[40];
+    parseOsLoadKey(client->applicationId, PARSE_INSTALLATION_ID, temp, sizeof(temp));
+    if (temp[0] != '\0') {
+        parseSetInstallationId((ParseClient)client, temp);
+    }
+
+    parseOsLoadKey(client->applicationId, PARSE_SESSION_TOKEN, temp, sizeof(temp));
+    if (temp[0] != '\0') {
+        parseSetSessionToken((ParseClient)client, temp);
+    }
+
+    parseOsLoadKey(client->applicationId, PARSE_LAST_PUSH_TIME, temp, sizeof(temp));
+    if (temp[0] != '\0') {
+        client->lastPushTime = strdup(temp);
+    }
+
+    curl_global_init(CURL_GLOBAL_ALL);
+
+    return (ParseClient)client;
 }
 
 ParseClient parseInitialize(
@@ -539,7 +585,13 @@ static void parseSendRequestInternal(
         }
     }
 
-    int urlSize = strlen("https://api.parse.com");
+    int urlSize = 0;
+    if(clientInternal->serverURL != NULL){
+        urlSize = strlen(clientInternal->serverURL);
+    }
+    else {
+        urlSize = strlen(PARSE_DEFAULT_SERVER_URL);
+    }
     urlSize += strlen(httpPath) + 1;
     char* getEncodedBody = NULL;
     if (getRequestBody) {
@@ -551,7 +603,15 @@ static void parseSendRequestInternal(
         if (callback != NULL) callback(client, ENOMEM, 0, NULL);
         return;
     }
-    strncat(fullUrl, "https://api.parse.com", urlSize);
+    
+    if(clientInternal->serverURL != NULL){
+        strncat(fullUrl, clientInternal->serverURL, urlSize);
+    }
+    else {
+        strncat(fullUrl, PARSE_DEFAULT_SERVER_URL, urlSize);
+    }
+
+    
     strncat(fullUrl, httpPath, urlSize - strlen(fullUrl));
     if (getRequestBody) {
         strncat(fullUrl, "?", urlSize - strlen(fullUrl));


### PR DESCRIPTION
#63 

1. Add parseInitializeWithServerURL() to include/parse.h
2. Add parseInitializeWithServerURL() implementation to unix/src/parse.c
